### PR TITLE
Add pawn.json for dependency management and easy run method

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+*.pwn linguist-language=Pawn
+*.inc linguist-language=Pawn

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+#
+# Package only files
+#
+
+# Compiled Bytecode, precompiled output and assembly
+*.amx
+*.lst
+*.asm
+
+# Vendor directory for dependencies
+dependencies/
+
+# Dependency versions lockfile
+pawn.lock
+
+
+#
+# Server/gamemode related files
+#
+
+# compiled settings file
+# keep `samp.json` file on version control
+# but make sure the `rcon_password` field is set externally
+# you can use the environment variable `SAMP_RCON_PASSWORD` to do this.
+server.cfg
+
+# Plugins directory
+plugins/
+
+# binaries
+*.exe
+*.dll
+*.so
+announce
+samp03svr
+samp-npc
+
+# logs
+logs/
+server_log.txt
+
+#
+# Common files
+#
+
+*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ http://forum.sa-mp.com/showthread.php?t=648101
 
 ## Usage
 
-Simply grab and run:
+Build with:
 
 ```bash
-sampctl package get fusez/Map-Editor-V3
-cd Map-Editor-V3
-sampctl package run
+sampctl package ensure
+sampctl package build
 ```
 
-And connect to `localhost:7777`.
+Running with `sampctl package run` does not work yet as the script is a
+filterscript not a generic script.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
+# Map-Editor-V3
+
+[![sampctl](https://shields.southcla.ws/badge/sampctl-Map--Editor--V3-2f2f2f.svg?style=for-the-badge)](https://github.com/fusez/Map-Editor-V3)
+
 For more information, see this forum post on SA-MP Forums:
 http://forum.sa-mp.com/showthread.php?t=648101
+
+## Usage
+
+Simply grab and run:
+
+```bash
+sampctl package get fusez/Map-Editor-V3
+cd Map-Editor-V3
+sampctl package run
+```
+
+And connect to `localhost:7777`.

--- a/filterscripts/mapedit.pwn
+++ b/filterscripts/mapedit.pwn
@@ -362,3 +362,7 @@ public OnPlayerClickMap(playerid, Float:fX, Float:fY, Float:fZ) {
 #include "mapedit/building/call.pwn"
 #include "mapedit/buildlist/call.pwn"
 #include "mapedit/printsuccess/call.pwn" // has to be at the end of callback list, prints a message if called
+
+main() {
+    //
+}

--- a/filterscripts/mapedit/matsize/func.pwn
+++ b/filterscripts/mapedit/matsize/func.pwn
@@ -6,7 +6,6 @@ GetMaterialSizeName(materialsize, name[], name_size) {
     } else {
         format(name, name_size, "Unknown Material Size (%i)", materialsize);
     }
-    return name;
 }
 
 GetMaterialSize(search[]) {

--- a/pawn.json
+++ b/pawn.json
@@ -1,0 +1,11 @@
+{
+	"user": "fusez",
+	"repo": "Map-Editor-V3",
+	"entry": "filterscripts/mapedit.pwn",
+	"output": "filterscripts/mapedit.amx",
+	"dependencies": [
+		"sampctl/samp-stdlib",
+		"maddinat0r/sscanf",
+		"oscar-broman/strlib"
+	]
+}


### PR DESCRIPTION
Please read this [Pull Request Note](https://github.com/Southclaws/sampctl/wiki/Pull-Request-Note)

- added Pawn Package files
- added .pwn and .inc to .gitattributes for proper language detection by GitHub
- added sampctl badge and build instructions to readme
- added all necessary dependencies to pawn.json
- added missing main() entrypoint
- removed invalid array return in GetMaterialSizeName

This allows users to simply run `sampctl package build` to automatically install all dependencies and compile it.

Running with `sampctl package run` doesn't work due to the fact that the code is set up as a filterscript rather than a generic script that can run as either.