### PR TITLE
Fixed an issue when editing an object's position

### DIFF
--- a/filterscripts/mapedit/object/call.pwn
+++ b/filterscripts/mapedit/object/call.pwn
@@ -67,10 +67,10 @@ public OnPlayerEditObject(playerid, playerobject, objectid, response, Float:fX, 
                 SetObjectRot(objectid, g_ObjectData[objectid-1][OBJECT_DATA_MEMORY_RX], g_ObjectData[objectid-1][OBJECT_DATA_MEMORY_RY], g_ObjectData[objectid-1][OBJECT_DATA_MEMORY_RZ]);
                 ShowObjectDialog(playerid, DIALOGID_OBJECT_MAIN);
             }
-            case EDIT_RESPONSE_UPDATE: {
+            /*case EDIT_RESPONSE_UPDATE: {
                 SetObjectPos(objectid, fX, fY, fZ);
                 SetObjectRot(objectid, fRotX, fRotY, fRotZ);
-            }
+            }*/
         }
 
     }


### PR DESCRIPTION
The speed of moving the object and also the accuracy were compromised due to the use of:
```
SetObjectPos(objectid, fX, fY, fZ);
SetObjectRot(objectid, fRotX, fRotY, fRotZ);
```

This fix may also fully or partially solve this problem: https://github.com/fusez/Map-Editor-V3/issues/3